### PR TITLE
Uses the correct convert and redeem states

### DIFF
--- a/src/components/bond/BondAction/index.tsx
+++ b/src/components/bond/BondAction/index.tsx
@@ -141,7 +141,6 @@ const BondAction = ({
     if (componentType === BondActions.Redeem) {
       previewRedeem(BondAmount).then((r) => {
         const [paymentTokens, collateralTokens] = r
-        console.log({ paymentTokens }, collateralTokens)
         // returned in paymentTokens, collateralTokens
         setPreviewRedeemVal([
           formatUnits(paymentTokens, bondInfo?.paymentToken.decimals),
@@ -225,11 +224,9 @@ const BondAction = ({
 
   const isActionDisabled = useMemo(() => {
     if (isConvertComponent) {
-      console.log(isConvertable)
       return isConvertable !== true
     }
     if (componentType === BondActions.Redeem) {
-      console.log(isRedeemable)
       return isRedeemable !== true
     }
   }, [isConvertComponent, componentType, isConvertable, isRedeemable])
@@ -273,9 +270,7 @@ const BondAction = ({
       }),
     })
   } else if (isDefaulted) {
-    console.log('defaulted')
     const [paymentTokensAmount, collateralTokensAmount] = previewRedeemVal
-    console.log(collateralTokensAmount, paymentTokensAmount)
     assetsToReceive.push({
       token: bondInfo?.collateralToken,
       value: Number(collateralTokensAmount).toLocaleString(undefined, {

--- a/src/components/bond/BondAction/index.tsx
+++ b/src/components/bond/BondAction/index.tsx
@@ -263,14 +263,17 @@ const BondAction = ({
     })
   } else if (isPaid) {
     const [paymentTokensAmount] = previewRedeemVal
+    const value = isConvertComponent ? previewConvertVal : paymentTokensAmount
+
     assetsToReceive.push({
       token: bondInfo?.paymentToken,
-      value: Number(paymentTokensAmount).toLocaleString(undefined, {
+      value: Number(value).toLocaleString(undefined, {
         maximumSignificantDigits: bondInfo?.paymentToken?.decimals,
       }),
     })
   } else if (isDefaulted) {
     const [paymentTokensAmount, collateralTokensAmount] = previewRedeemVal
+
     assetsToReceive.push({
       token: bondInfo?.collateralToken,
       value: Number(collateralTokensAmount).toLocaleString(undefined, {

--- a/src/pages/BondDetail/index.tsx
+++ b/src/pages/BondDetail/index.tsx
@@ -110,6 +110,7 @@ export const getBondStates = (bond: BondInfo) => {
   const isPartiallyPaid = false // TODO ADD THIS TO THE GRAPH
   const isDefaulted = bond?.state === 'defaulted'
   const isPaid = bond?.state === 'paidEarly' || bond?.state === 'paid'
+  const isActive = bond?.state === 'active'
   const isMatured = isDefaulted || isPaid
   return {
     isMatured,
@@ -117,6 +118,7 @@ export const getBondStates = (bond: BondInfo) => {
     isPartiallyPaid,
     isDefaulted,
     isPaid,
+    isActive,
   }
 }
 


### PR DESCRIPTION
This fixes the redeem/convert states to show the correct data. 

Some subgraph data is being returned incorrectly, causing this to show a defaulted state when it should be showing a paid state which caused some of the unexpected behavior https://github.com/porter-finance/subgraph/issues/31


Follow ups needed #359

Please merge when ready. I am ready to merge from my side